### PR TITLE
No comments fix

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,12 @@ use std::fmt::Display;
 use std::fmt;
 
 #[derive(Debug)]
+pub struct HttpError {
+    pub code: u16,
+    pub url: String,
+}
+
+#[derive(Debug)]
 pub enum HnError {
     // Error used when parsing of an HTML document fails
     HtmlParsingError,
@@ -12,7 +18,7 @@ pub enum HnError {
     // Error used when a client fails to authenticate
     AuthenticationError,
     // Error raised from a failure during an HTTP request/response 
-    HttpError,
+    HttpError(HttpError),
 }
 
 impl Display for HnError {
@@ -27,8 +33,11 @@ impl Display for HnError {
             HnError::AuthenticationError => {
                 write!(f, "A client failed to authenticate. Please check credential information, and authentication frequency")
             }
-            HnError::HttpError => {
-                write!(f, "A client failed during an HTTP request/response.")
+            HnError::HttpError(http_err) => {
+                write!(f, "A client failed during an HTTP request/response; url '{}', code '{}'",
+                    http_err.url,
+                    http_err.code,
+                )
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use std::env;
-use log;
 use std::error::Error;
 use env_logger;
 use hacker_news::cli::HnCommand;


### PR DESCRIPTION
# No Comments Fix

## Description

Previously when using the HTML client, if you requested comments for an ID with no comments it produced an error. The underlying cause was a query for the root of the comment table was producing no results, which was reported as an error. To resolve this, there is now a check which sees if the query got any results, and if none were found, simply returns an empty vector.

Fixes # (issue)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Version Information:
Crate Version: 0.1.0

