### PR TITLE
Refactor comment tree logic

### DIFF
--- a/src/client/html_client.rs
+++ b/src/client/html_client.rs
@@ -20,7 +20,7 @@ use crate::parser::HtmlParse;
 use crate::parser::ListingsParser;
 use crate::parser::CommentsParser;
 use crate::parser::extract_fnid;
-use crate::parser::create_comment_tree;
+use crate::parser::comments::create_comment_tree;
 use crate::model::Id;
 use crate::model::Listing;
 use crate::model::Date;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,11 +1,9 @@
 use std::error::Error;
-use std::collections::VecDeque;
 use lazy_static::lazy_static;
 use regex::Regex;
 use scraper;
 use scraper::Html;
 use scraper::ElementRef;
-use crate::model::Comment;
 use crate::error::HnError;
 
 pub mod comments;
@@ -33,9 +31,6 @@ lazy_static! {
     static ref FNID_REGEX: Regex =  Regex::new(r#"<input.*value="(.+?)".*>"#).unwrap();
 }
 
-const COMMENT_INDENT_INCR: u32 = 40;
-
-
 pub fn extract_fnid(el: &ElementRef) -> Result<String, Box<dyn Error>> {
     let text = el.html();
     let captures = match FNID_REGEX.captures(&text) {
@@ -54,46 +49,5 @@ pub fn extract_fnid(el: &ElementRef) -> Result<String, Box<dyn Error>> {
     };
 
     Ok(fnid)
-}
-
-pub fn extract_comments(html: &Html) -> Result<Vec<Comment>, Box<dyn Error>> {
-    let comments = CommentsParser::parse(html)?;
-
-    Ok(comments)
-
-}
-
-pub fn create_comment_tree(comments: Vec<Comment>) -> Vec<Comment> {
-    let mut q = VecDeque::from(comments);
-    let mut forest = Vec::new();
-
-    while let Some(root) = q.pop_front() {
-        forest.push(root);
-        let ptr = forest.last_mut().unwrap();
-        _create_comment_tree(&mut q, ptr);
-    }
-
-    forest
-}
-
-#[allow(clippy::comparison_chain)]
-fn _create_comment_tree(q: &mut VecDeque<Comment>, parent: &mut Comment) {
-    let mut last: Option<&mut Comment> = None;
-    while let Some(c) = q.front() {
-        if c.indent == parent.indent + COMMENT_INDENT_INCR {
-            let c = q.pop_front().unwrap();
-            parent.children.push(c);
-            last = Some(parent.children.last_mut().unwrap());
-        }
-        else if c.indent > parent.indent + COMMENT_INDENT_INCR {
-            let next_parent = last.take()
-                .expect("Jumped a nesting level in comment node hierarchy");
-            _create_comment_tree(q, next_parent);
-        }
-        else {
-            return;
-        }
-    }
-
 }
 


### PR DESCRIPTION
# Refactor comment tree logic

## Description
Place the comment tree logic within the comment parser module. Not a
real logic change, just code base cleanliness. Overall a minor refactor.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Version Information:
Crate Version: 0.1.0
