### PR TITLE
Resolved bug with duplicated comment text

### DIFF
--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -93,13 +93,13 @@ impl CommentsParser {
     fn parse_text(node: &ElementRef, id: Id) -> Result<String, Box<dyn Error>> {
 
         // Select inner text from root of comment text node
-        let mut text = node.select(&QS_COMMENT_TEXT)
+        let text_node = node.select(&QS_COMMENT_TEXT)
             .next()
             .ok_or_else(|| {
                 log::error!("Failed to find comment text for id = {}", id);
                 HnError::HtmlParsingError
-            })?
-            .text()
+            })?;
+        let mut text = text_node.text()
             .next()
             .ok_or_else(|| {
                 log::error!("Failed to extract inner text for comment id = {}", id);
@@ -107,7 +107,7 @@ impl CommentsParser {
                 msg.as_str().to_owned()
             })?
             .to_string();
-        parser::append_more_text_nodes(node, &QS_COMMENT_TEXT, &mut text);
+        parser::append_more_text_nodes(node, &QS_COMMENT_MORE_TEXT, &mut text);
 
         Ok(text)
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -48,18 +48,18 @@ fn ancestor<'a>(node: &'a ElementRef, height: u32) -> Option<ElementRef<'a>> {
 // Search for any additional nodes of text, and append to buffer 
 fn append_more_text_nodes(node: &ElementRef, qs: &Selector, text: &mut String, ) {
     for child in node.select(&qs) {
-        let more_text = match child.text().next() {
+        match child.text().next() {
             None => {
                 // This branch handles a <p> node with no inner text. With no inner
                 // text, there is nothing to append, and we simply continue
                 continue;
             }
-            Some(more_text) => more_text,
-        };
-
-        // We add a newline since we're concatenating <p> node text together
-        text.push('\n');
-        text.push_str(&more_text);
+            Some(more_text) => {
+                // We add a newline since we're concatenating <p> node text together
+                text.push('\n');
+                text.push_str(&more_text);
+            },
+        }
     }
 }
 


### PR DESCRIPTION
# Bug Fix (Issue 23) Repeated Comment Text
Resolved bug with duplicated comment text. Spent entirely too long to
realize I was using the wrong query string when looking for the "more
text" nodes to append.

## Description
Fixes #23 

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Version Information:
Crate Version: 0.1.0
