### PR TITLE
Resolve Dead/Flagged Comment Parsing

### DIFF
--- a/src/client/html_client.rs
+++ b/src/client/html_client.rs
@@ -290,7 +290,7 @@ mod tests {
     fn test_comments() -> Result<(), Box<dyn Error>> {
         setup();
         let client = Client::new("", "");
-        let comments = client._comments(100)?;
+        let comments = client.thread(100)?;
         log::debug!("comments = {:?}", comments);
 
         Ok(())

--- a/src/model.rs
+++ b/src/model.rs
@@ -28,9 +28,9 @@ pub struct Listing {
 pub struct Comment {
     pub user: String,
     pub id: Id,
-    pub text: String,
+    pub text: Option<String>,
     pub indent: u32,
-    // pub bool: deleted,
+    pub dead: bool,
     pub children: Vec<Comment>,
 }
 


### PR DESCRIPTION
# Resolve Dead/Flagged Comment Parsing

## Description
Added in a dead flag to the comment data structure definition, and added
in logic to parse out whether a comment is dead. Also since dead
comments by default show up as "[flagged]" with no user text, when a
comment is recognized as dead, I am not parsing for the user comment
text.

Potentially this should be updated in the future if I add in user
authentication, which adds a setting to show dead comments.

Fixes # (issue)
* https://github.com/cljacoby/hacker-news/issues/22

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Version Information:
Crate Version: 0.1.0
