### PR TITLE
Remove Auth Arguments from HTML `Client::new()`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-# Pull Request Template
+# Title 
 
 ## Description
 

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -38,11 +38,11 @@ impl HnCommand for Login {
             .value_of("username")
             .ok_or("username is required for login")?;
         let password = matches
-        .value_of("password")
-        .ok_or("password is required for login")?;
+            .value_of("password")
+            .ok_or("password is required for login")?;
         
-        let client = Client::new(username, password);
-        client.login()?;
+        let client = Client::new();
+        client.login(username, password)?;
 
         Ok(())
     }

--- a/src/cli/news.rs
+++ b/src/cli/news.rs
@@ -17,7 +17,7 @@ impl HnCommand for News {
     }
 
     fn cmd(_matches: &ArgMatches) -> Result<(), Box<dyn Error>> {
-        let client = Client::new("", "");
+        let client = Client::new();
         let listings = client.news()?;
         let grid: Vec<Vec<String>> = listings.into_iter().map(|l| vec![
             l.id.clone().to_string(),

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -29,7 +29,7 @@ impl HnCommand for Query {
         };
         let id: Id = id.parse()?;
 
-        let client = Client::new("test", "test");
+        let client = Client::new();
         let item = client.item(id)?;
         println!("item = {:#?}", item);
         

--- a/src/cli/thread.rs
+++ b/src/cli/thread.rs
@@ -30,7 +30,7 @@ impl HnCommand for Thread {
         };
         let id: Id = id.parse()?;
 
-        let client = Client::new("test", "test");
+        let client = Client::new();
         let thread = client.thread(id)?;
         let json = serde_json::to_string(&thread)?;
         println!("{}", json);

--- a/src/client/html_client.rs
+++ b/src/client/html_client.rs
@@ -37,17 +37,13 @@ lazy_static! {
 
 pub struct Client {
     http_client: reqwest::blocking::Client,
-    username: String,
-    password: String,
     cookie: RefCell<Option<(String, String)>>,
 }
 
 impl Client {
 
-    pub fn new(username: &str, password: &str) -> Self {
+    pub fn new() -> Self {
         Self {
-            username: String::from(username),
-            password: String::from(password),
             http_client: reqwest::blocking::Client::new(),
             cookie: RefCell::new(None),
         }
@@ -126,10 +122,10 @@ impl Client {
         Ok(fnid)
     }
 
-    pub fn login(&self) -> Result<(), Box<dyn Error>> {
+    pub fn login(&self, username: &str, password: &str) -> Result<(), Box<dyn Error>> {
         let mut formdata = HashMap::new();
-        formdata.insert("acct", &self.username);
-        formdata.insert("pw", &self.password);
+        formdata.insert("acct", username);
+        formdata.insert("pw", password);
         let goto = "newest".to_string();
         formdata.insert("goto", &goto);
 
@@ -268,7 +264,7 @@ mod tests {
     #[test]
     fn test_news() -> Result<(), Box<dyn Error>> {
         setup();
-        let client = Client::new("filler_user", "filler_pwd");
+        let client = Client::new();
         let listings = client.news()?;
         log::info!("Successfully called Client::news()");
         log::trace!("Listings output from Client::news() = {:?}", listings);
@@ -279,7 +275,7 @@ mod tests {
     #[test]
     fn test_item() -> Result<(), Box<dyn Error>> {
         setup();
-        let client = Client::new("filler_user", "filler_pwd");
+        let client = Client::new();
         let item = client.item(25925926)?;
         log::debug!("test_item item = {:#?}", item);
 
@@ -289,7 +285,7 @@ mod tests {
     #[test]
     fn test_comments() -> Result<(), Box<dyn Error>> {
         setup();
-        let client = Client::new("", "");
+        let client = Client::new();
         let comments = client.thread(100)?;
         log::debug!("comments = {:?}", comments);
 
@@ -317,8 +313,8 @@ mod tests {
             }
         };
         
-        let client = Client::new(&user, &pwd);
-        client.login()?;
+        let client = Client::new();
+        client.login(&user, &pwd)?;
 
         Ok(())
     }

--- a/src/client/json_client.rs
+++ b/src/client/json_client.rs
@@ -194,16 +194,6 @@ mod tests {
     use std::error::Error;
     use crate::util::setup;
 
-
-    #[test]
-    fn test_get_invalid_url() -> Result<(), Box<dyn Error>> {
-        let client = JsonClient::new();
-        let url = format!("https://www.google.com/invalid_path");
-        let _resp = client.get_url(&url)?;
-
-        Ok(())
-    }
-
     #[test]
     fn test_item() -> Result<(), Box<dyn Error>> {
         setup();


### PR DESCRIPTION
# Pull Request Template

## Description

Change the function signature of the HTML client new method from this:
```rust
use hacker_news::client::html_client::Client;

let client = Client::new("user", "pass");
```
To this:
```rust
use hacker_news::client::html_client::Client;

let client = Client::new();
client.login("user", "pass")?;
```

This is more intuitive given `new()` functions generally don't take arguments. Additionally, if read only is the primary use case, than this is a more intuitive and easy-to-use API.

Fixes # (issue)
https://github.com/cljacoby/hacker-news/issues/15

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Version Information:
Crate Version: 0.1.1
